### PR TITLE
Update falsepositive.list to add click.ltms.app

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -115,3 +115,4 @@ crpkosovo.org
 zenodo.org
 google.ru
 aliexpress.us
+click.ltms.app


### PR DESCRIPTION
**Domains or links**
`click.ltms.app`

**More Information**
How did you discover your web site or domain was listed here?
1. Customer reported our domain was listed on https://www.virustotal.com/gui/domain/click.ltms.app/detection

**Have you requested removal from other sources?**
Not currently listed on OpenPhish or Phishtank

**Additional context**
We build tooling for email marketers, so it is common for our domains to be copy and pasted into Phishing emails in an attempt to make them look legitimate.  We believe this domain was added to your list for that reason.

All content on this domain is generated by paying customers.  Using our service for nefarious purposes is against our terms of service and we would take any report of malicious usage very seriously.  We welcome any reports of malicious content at [security@litmus.com](mailto:security@litmus.com)