### PR TITLE
[FALSE-POSITIVE] Bio Sites domain

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -54,3 +54,4 @@ voicemod.net
 westandsons.co.nz
 zenodo.org
 aliexpress.us
+bio.site


### PR DESCRIPTION
**Domains or links**
bio.site

**More Information**
How did you discover your web site or domain was listed here?
- Incorrectly marked as Phishing in [Virus Total](https://www.virustotal.com/gui/url/51986ccb0680b16bf8512deec87c6adc76ae105ed7a5bd21cedc635c7f97048f)

**Have you requested removal from other sources?**
I have requested removal from ArcSight Threat Intelligence, CRDF, MalwareURL and a few other security providers in the past, but at the moment PhishingDatabase is the only one flagging us according to the report linked above

**Additional context**
I'm a manager with Squarespace and the "bio.site" domain is used to host websites created by our users, and we monitor for malicious behavior and take sites down when appropriate.
We're additionally working on improving our ability to detect malicious sites faster. You can check [biosites.com](https://biosites.com) to learn more about the product.