### PR TITLE
Add heylink.me domains to falsepositives

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -116,3 +116,6 @@ crpkosovo.org
 zenodo.org
 google.ru
 aliexpress.us
+heylink.me
+app.heylink.me
+heyl.ink


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):

```
heylink.me
app.heylink.me
heyl.ink
```

## Impersonated domain

```
heylink.me
app.heylink.me
heyl.ink
```

## Describe the issue

Greetings!

Our website https://heylink.me/ is currently marked as a "phishing" in Phishing.Database.
Requested domains are properties of our company

Our web application provides convenient tools for about 8M registered users worldwide to create their public pages. Some of them are publishing inappropriate stuff from time to time and our tech team is doing a lot of things to moderate the user content and clean it from spam, phishing and other inappropriate behaviours that breach our T&C.

We support your vision of a clean and safe Internet. We will be glad to cooperate with you in order to sort it out.

Thank you for your kind attention,

Serg HeyLink.me Tech Team Lead

serg@heylink.me