### PR TITLE
[FALSE-POSITIVE] walletconnect.network

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -119,3 +119,5 @@ crpkosovo.org
 zenodo.org
 google.ru
 aliexpress.us
+walletconnect.network
+airdrop.walletconnect.network

--- a/falsepositive.list
+++ b/falsepositive.list
@@ -119,5 +119,3 @@ crpkosovo.org
 zenodo.org
 google.ru
 aliexpress.us
-walletconnect.network
-airdrop.walletconnect.network

--- a/falsepositive.list
+++ b/falsepositive.list
@@ -119,3 +119,4 @@ crpkosovo.org
 zenodo.org
 google.ru
 aliexpress.us
+walletconnect.network

--- a/falsepositive_all.list
+++ b/falsepositive_all.list
@@ -1,2 +1,3 @@
 .flk-ipfs.xyz
 .formaloo.net
+.walletconnect.network


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
`walletconnect.network`
`airdrop.walletconnect.network`

## Impersonated domain
<!-- Required. Use Back ticks. -->
NA

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
These domains who are part of an initiative by the WalletConnect Foundation, were mistakenly marked as phishing.

Please see:
- LinkedIn announcement: https://www.linkedin.com/posts/walletconnect-network_the-connect-token-wct-airdrop-is-here-activity-7244335908143919106-GlIc?utm_source=share&utm_medium=member_desktop
- X post: https://x.com/timelesswallet/status/1861516622545981465

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->
https://www.virustotal.com/gui/domain/airdrop.walletconnect.network
https://www.virustotal.com/gui/domain/walletconnect.network

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
