### PR TITLE
[falsepositive.list] Added confreriedes650.org

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -55,3 +55,4 @@ westandsons.co.nz
 zenodo.org
 aliexpress.us
 bio.site
+confreriedes650.org


### PR DESCRIPTION
**Domains or links**
confreriedes650.org

**More Information**
How did you discover your web site or domain was listed here? --> From a user report.

**Have you requested removal from other sources?**
Yes, back in 2020 when the site was hacked and promptly fixed, but I don’t remember where I made the request.

**Additional context**
Site is marked clean in every other source as can be seen on https://www.virustotal.com/gui/url/6b281a0475995d5bc4924bb2ded0f3b4b9fbe019f5d01dd6882cfe21482056e6
