### PR TITLE
add www.sibalogtv.com to falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -50,6 +50,7 @@ pitch.com
 signin.quicken.com
 sakthivel.com
 r.secprf.com
+www.sibalogtv.com
 online1.snapsurveys.com
 surreycarsguildford.com
 surveysparrow.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
www.sibalogtv.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```

```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
Adding `www.sibalogtv.com` to the list of false positives to address https://github.com/Phishing-Database/Phishing.Database/issues/972

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
