### PR TITLE
add sea-storage.hostwinds.net to falsepositives

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -87,6 +87,7 @@ clover.co.jp
 ethans.link
 lp.vp4.me
 bbvanetcash.mx
+sea-storage.hostwinds.net
 stats.sender.net
 voicemod.net
 walletconnect.network


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
sea-storage.hostwinds.net
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```

```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
Fixes https://github.com/Phishing-Database/Phishing.Database/issues/966

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
