### PR TITLE
add  news-dofus.com to blocklists

### DIFF
--- a/add-link
+++ b/add-link
@@ -1,4 +1,3 @@
-https://www.news-dofus.com/fr/mmorpg/event/cadeaux/parchemin/succes.php 
 http://9428beb8.centroesserevalverde.it/za?c95b469cc2004bdf9a742bef611e5a18&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIGCAEQABhAMgYIAhAAGEAyBggDEAAYQ301e38b3
 http://amanita.com.my/l/
 http://anhhungphat.vn/wp-content/plugins/seo-site-admin/luno/nluno/cbhnfc4smgy2b50lmmu43upt.php?rand=13InboxLightaspxn.1774256418&fid.4.1252899642&fid=1&fav.1&rand.13InboxLight.aspxn.1774256418&fid.1252899642&fid.1&fav.1&email=&emailID=&.rand=13InboxLight.aspx?n=1774256418&fid=4#n=1252899642&fid=1&fav=1
@@ -247,6 +246,7 @@ https://www.kmspicoofficial.com
 https://www.kmspicoofficial.com/kmspico-download-official/
 https://www.manitowocice.com/Media/Manitowocice/robux1.html
 https://www.megahause.de
+https://www.news-dofus.com/fr/mmorpg/event/cadeaux/parchemin/succes.php 
 https://www.officialkmspico.com
 https://www.poponuss.de
 https://www.probacons.com/kmspico/

--- a/add-link
+++ b/add-link
@@ -1,4 +1,4 @@
- https://www.news-dofus.com/fr/mmorpg/event/cadeaux/parchemin/succes.php 
+https://www.news-dofus.com/fr/mmorpg/event/cadeaux/parchemin/succes.php 
 http://9428beb8.centroesserevalverde.it/za?c95b469cc2004bdf9a742bef611e5a18&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIGCAEQABhAMgYIAhAAGEAyBggDEAAYQ301e38b3
 http://amanita.com.my/l/
 http://anhhungphat.vn/wp-content/plugins/seo-site-admin/luno/nluno/cbhnfc4smgy2b50lmmu43upt.php?rand=13InboxLightaspxn.1774256418&fid.4.1252899642&fid=1&fav.1&rand.13InboxLight.aspxn.1774256418&fid.1252899642&fid.1&fav.1&email=&emailID=&.rand=13InboxLight.aspx?n=1774256418&fid=4#n=1252899642&fid=1&fav=1

--- a/add-link
+++ b/add-link
@@ -1,3 +1,4 @@
+ https://www.news-dofus.com/fr/mmorpg/event/cadeaux/parchemin/succes.php 
 http://9428beb8.centroesserevalverde.it/za?c95b469cc2004bdf9a742bef611e5a18&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIGCAEQABhAMgYIAhAAGEAyBggDEAAYQ301e38b3
 http://amanita.com.my/l/
 http://anhhungphat.vn/wp-content/plugins/seo-site-admin/luno/nluno/cbhnfc4smgy2b50lmmu43upt.php?rand=13InboxLightaspxn.1774256418&fid.4.1252899642&fid=1&fav.1&rand.13InboxLight.aspxn.1774256418&fid.1252899642&fid.1&fav.1&email=&emailID=&.rand=13InboxLight.aspx?n=1774256418&fid=4#n=1252899642&fid=1&fav=1

--- a/add-wildcard-domain
+++ b/add-wildcard-domain
@@ -169,6 +169,7 @@ michaelconstantinebhanos.com
 mistitis.ug
 musangking.com.my
 neburfaw.xyz
+news-dofus.com
 nico.sa
 nicolascoolman.com
 nicoslag.ru


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
news-dofus.com
https://www.news-dofus.com/fr/mmorpg/event/cadeaux/parchemin/succes.php 
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
dofus.com
```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
Fixes https://github.com/Phishing-Database/phishing/issues/566

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->
https://urlscan.io/result/2badba8f-55d3-4923-a217-315280344136/

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>

![2badba8f-55d3-4923-a217-315280344136](https://github.com/user-attachments/assets/307c5570-4a5f-468f-97db-1ce2dc9fcba2)

</details>
