### PR TITLE
Add GitHub hosted facebook lure

### DIFF
--- a/add-link
+++ b/add-link
@@ -500,6 +500,7 @@ https://gevra908.wixsite.com/my-site-1
 https://gitelt.net/serv-luno-act%20/luno/
 https://graficasutileza.com.br/redirect/index.php?email=
 https://hip-concise-booklet.glitch.me/#
+https://html-preview.github.io/?url=https://github.com/marshedsky/facebook.io/blob/main/index.html
 https://ia801406.us.archive.org/28/items/abbakaz217/abbakaz/abbakaz1.html?Username=general@yahoo.com
 https://icloud.com-mob.support/d/
 https://imagizer.imageshack.com/img922/1126/OmihEE.jpg
@@ -1593,4 +1594,3 @@ https://www.spouscshop.trade/linkednew/index.htm
 https://www.univer-dofus.com/fr/mmorpg/actualites/recompenses/succes.php
 https://xamo-82976.web.app/#
 https://yuppiiechef.com/account/
-https://html-preview.github.io/?url=https://github.com/marshedsky/facebook.io/blob/main/index.html

--- a/add-link
+++ b/add-link
@@ -1593,3 +1593,4 @@ https://www.spouscshop.trade/linkednew/index.htm
 https://www.univer-dofus.com/fr/mmorpg/actualites/recompenses/succes.php
 https://xamo-82976.web.app/#
 https://yuppiiechef.com/account/
+https://html-preview.github.io/?url=https://github.com/marshedsky/facebook.io/blob/main/index.html


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
https://html-preview.github.io/?url=https://github.com/marshedsky/facebook.io/blob/main/index.html
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
facebook.com
```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
Threat actor abusing a GitHub feature to host a Facebook lure.  The related repository can be viewed at https://github.com/Marshedsky/Facebook.io.  https://github.com/Marshedsky/Facebook.io/blob/main/index.php/index.php shows a POST request used to send the login credentials to `ignitewithin1189@gmail.com`.

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->
https://infosec.exchange/@urldna/113771269693201764
https://urlscan.io/result/61947721-03e1-4cda-b12e-7094a3940013/

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>

![61947721-03e1-4cda-b12e-7094a3940013](https://github.com/user-attachments/assets/23179e08-d7b0-4ae1-b1ac-9ad108005d7f)
![image](https://github.com/user-attachments/assets/91ef5120-bc98-4015-af58-ef6555ab7299)

</details>
