### PR TITLE
add cloudflare protected domains and URIs - USPS delivery failure lures

### DIFF
--- a/add-link
+++ b/add-link
@@ -1342,6 +1342,12 @@ https://info-trackingcok.cc/info/
 https://info-trackingcom.cc/info/
 https://info-trackingcor.cc/info/
 https://info-trackingcov.cc/info/
+https://informed.deliveryiga.top/l/
+https://informed.deliveryluxrzv.top/i/ 
+https://informed.deliveryuyl.top/l/ 
+https://informed.deliverywoxdkv.top/i/
+https://informed.deliverywtq.top/us/
+https://informed.deliverywwm.top/us/
 https://ismurk.com/MoVicci/ 
 https://ispsongo.ac.mz/aaheygreaa/PageUpdated/ampt.html?app=
 https://itsssl.com/Zqcp9
@@ -1391,6 +1397,7 @@ https://ofitzo.xyz/update/index.php?email=
 https://osapol.net/A4pavic/ 
 https://ountab.com/HYPE/
 https://p.usertrackhst.top/l/
+https://p.usertrackktc.top/l/ 
 https://packtrack-help.top/i/
 https://parceltrack-help.top/i/
 https://pbwctuhcnmvslir.usa.cc/Africanacity/v3/index.php
@@ -1518,6 +1525,7 @@ https://tracktoy.top/us/
 https://trendingtopics.id/1ndex.php
 https://trunkapar.co.trunkersfit.com/trunkinvapar/365/b6fd3862fce3a50d3b535e25ddf67f9f/bxy1txk7w0s0ak2jm467amc8mb4gyx.php
 https://trunkapar.co.trunkersfit.com/trunkinvapar/login.php?email=
+https://u.infotracktou.top/l/ 
 https://u7904673.ct.sendgrid.net/wf/click?upn=hHyPRBXA4hoRoUA9febkAzSr9zKt6lwalwwKMXAhj8g-3D_p9tAftU4ATe-2BD0JmFt6eQCmgth-2BTf3GRouxZ1mjdUXTZZSYeioKZrnPZisydlMK5R-2FnoNfT-2Bd4M3-2F3RJfjvycDLYr6dlOGPVpTVd1yTojvWdrHmJP5565iH-2F507zyDhFKsH4qIz6DzRXwAWJIEjj68RsYZupOENeh3DH8w9D1TC26m58rhHD9zAHuu-2BY1pH67V90CpRxhk6NWWu2THNG-2F-2BLpTRvcrEeDMUC1w15rli896JqGGXqXQRUm-2BvE39sGiFTe0t15GczRHATuVMDhu579CIMxg69huWnNm86pBIFxX4uXpmURsil9vmZZDYyZdnKCp2kKrsZgY-2Fgay6HDWu4pkzYxD3WX4lfaTpnlbIrD2ZbPv7DgtsiX2i9o-2BIhKnduxL1J0wXsNGPd2Nq3iZhpWbBJbDimAEODw9zlsL-2F7o-3D
 https://ujiooslmnj.ubpages.com/hisjuk/
 https://ulingl.com/Aviop/
@@ -1557,6 +1565,7 @@ https://usps.com-eseg.top/mum/
 https://usps.com-isnly.top/i/
 https://usps.com-packtrack.top/i/
 https://usps.com-parceltrack.top/i/
+https://usps.com-rutyypupls.top/i/
 https://usps.com-shiptrace.top/i/
 https://usps.com-tackkmuno.top/i/
 https://usps.com-tackvslvr.top/i/
@@ -1584,6 +1593,7 @@ https://usps.com-trackbdp.top/us/
 https://usps.com-trackbdy.top/us
 https://usps.com-trackbeq.top/us
 https://usps.com-trackbfy.top/i
+https://usps.com-trackbgw.top/us/
 https://usps.com-trackbiz.top/us/
 https://usps.com-trackbke.top/us
 https://usps.com-trackbls.top/us/
@@ -2226,6 +2236,7 @@ https://usps.com-trackyrd.top/us/
 https://usps.com-trackytj.top/us/
 https://usps.com-trackytrt.top/i/
 https://usps.com-trackyvl.top/us/
+https://usps.com-trackyyea.top/l/ 
 https://usps.com-trackyza.top/us/
 https://usps.com-trackyzw.top/us/
 https://usps.com-trackyzy.top/us

--- a/add-wildcard-domain
+++ b/add-wildcard-domain
@@ -1646,6 +1646,12 @@ infobpha.top
 infoevtq.top
 infoihkl.top
 infokvpk.top
+informed.deliveryiga.top
+informed.deliveryluxrzv.top
+informed.deliveryuyl.top
+informed.deliverywoxdkv.top
+informed.deliverywtq.top
+informed.deliverywwm.top
 infovpli.top
 intrinsicisle.za.com
 ironturner.shop
@@ -1726,6 +1732,7 @@ osapol.net
 ostarcub.xyz
 otwareng.xyz
 ountab.com
+p.usertrackktc.top
 packtrack-help.top
 paipaisdvzxc.ru
 parceltrack-help.top
@@ -1891,6 +1898,7 @@ trackvpy.top
 triathlethe.ug
 tricazo.com
 tuskslacx.ug
+u.infotracktou.top
 ucnlkw.cyou
 ulingl.com
 unity-ladder.com
@@ -1947,6 +1955,9 @@ usps-xlx.shop
 usps-yju.shop
 usps-zbx.shop
 usps-zlb.shop
+usps.com-rutyypupls.top
+usps.com-trackbgw.top 
+usps.com-trackyyea.top
 uspsaka.vip 
 uspsake.vip
 uspsakf.vip


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
com-rutyypupls.top
com-trackbgw.top 
com-trackyyea.top
deliveryiga.top
deliveryluxrzv.top
deliveryuyl.top
deliverywoxdkv.top
deliverywtq.top
deliverywwm.top
infotracktou.top
usertrackktc.top
https://usps.com-trackbgw.top/us/
https://informed.deliveryluxrzv.top/i/ 
https://u.infotracktou.top/l/ 
https://p.usertrackktc.top/l/ 
https://informed.deliverywoxdkv.top/i/
https://informed.deliverywtq.top/us/
https://usps.com-trackyyea.top/l/ 
https://informed.deliveryuyl.top/l/ 
https://informed.deliveryiga.top/l/
https://usps.com-rutyypupls.top/i/
https://informed.deliverywwm.top/us/
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
tools.usps.com
```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
Cloudflare protected USPS delivery failure lures.

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>

![77b12b57-2ecd-4b92-bb87-ead385e877be](https://github.com/user-attachments/assets/7cbf08c4-630e-402e-9ebe-ddc950efabdb)

</details>
