### PR TITLE
Add batch of phishing domains

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -54,6 +54,7 @@ youareanidiot.cc
 discord.lossantossanto1.repl.co
 socialearn.co
 t.co
+3dmegastructures.com
 8vjejn.com
 8vpro.com
 8vproe.com
@@ -284,6 +285,7 @@ mikatafa.weebly.com
 mivezosikobo.weebly.com
 moxalabukeziro.weebly.com
 munuteme.weebly.com
+netflixxcxx.weebly.com
 nikonewakudofu.weebly.com
 nivirijimukavut.weebly.com
 nufivinob.weebly.com
@@ -589,6 +591,7 @@ lg0r3d.webwave.dev
 ljabsd.webwave.dev
 mnby8g.webwave.dev
 q35keh.webwave.dev
+notifications-lucky-cake-eastcloud67.fresfst.workers.dev
 portalpaxum.cokiwe2297.workers.dev
 fmovies.direct
 gosuslugi.directory


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
https://3dmegastructures.com/mmm-wwwv/new.index.html#example@protonmail.com
https://3dmegastructures.com/mmm-wwwv/new.index.html#example@gmail.com

https://netflixxcxx[.]weebly.com/

https://notifications-lucky-cake-eastcloud67.fresfst.workers.dev/?data=ZXhhbXBsZUBwcm90b25tYWlsLmNvbQ==

```

## Describe the issue
I was clearing out the Spam folder for my development email address (240 spam emails!), which led me to find these 3 sites. I believe that all of them should be added to the ``add-domain`` file, because the entire domain appears malicious for all of them.
(also, the ``?data`` flag on the workers site is base64, but it doesn't check if the base64 string is actually a target email address)

### Screenshot

<details><summary>Click to expand</summary>

![image](https://github.com/user-attachments/assets/8a35cd8e-c068-471d-ad40-5930b77c5ff1)
the "3dmegastructures" email, which leads to:
![image](https://github.com/user-attachments/assets/9306d112-871f-48ad-8640-f2e953db462e)

![image](https://github.com/user-attachments/assets/20ee0a9c-72a8-4c81-b1f6-79ee20029153)
a lazy netflix phish

![image](https://github.com/user-attachments/assets/8c2d4ee9-2f59-4c58-a808-40baba47c7dc)
wow, they've really expanded IPv4 ranges! (the cloudflare workers site, which leads to:)
![image](https://github.com/user-attachments/assets/4a11f4cb-6e60-446a-8214-ea398ed8d6ad)


</details>
