### PR TITLE
Adding phishing domains for Payhawk

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1022,3 +1022,6 @@ v2-extrafi.xyz
 wiflix.xyz
 wiflix.yachts
 coronavirus.zone
+portal-payhawk.com
+payhawk.com.co
+ihjdshfj.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):

```
https://portal-payhawk.com/?gad_source=1&gbraid=0&gclid=0
```

## Impersonated domain

```
portal.payhawk.com
```

## Describe the issue

These are the domains related to a targeted phishing campaign against the Payhawk.
