### PR TITLE
move links mistakenly placed in domain list to link list

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1000,16 +1000,6 @@ entelhcl.top
 usop.sobwykro.top
 swap-cow.top
 us-psues.top
-http://usps.com-trackaal.top/us/
-http://usps.com-trackcqi.top/us/
-http://usps.com-tracknpt.top/us/
-http://usps.com-trackphy.top/us/
-http://usps.com-trackpro.top/us/
-http://usps.com-trackrip.top/us/
-http://usps.com-tracksqf.top/us/
-http://usps.com-trackvtk.top/us/
-http://usps.com-trackyqn.top/us/
-http://usps.com-trackysb.top/us/
 atomic-wallet.trade
 www.0202.com.tw
 gosuslugi.uk

--- a/add-link
+++ b/add-link
@@ -912,6 +912,7 @@ http://usps.com-rutyypunb.top/i/
 http://usps.com-rutyypupls.top/i/
 http://usps.com-rutyypuwes.top/i/
 http://usps.com-rutyypuwnf.top/i/
+http://usps.com-trackaal.top/us/
 http://usps.com-trackabj.top/us/
 http://usps.com-trackabn.top/us/
 http://usps.com-trackabv.top/us/
@@ -1016,6 +1017,7 @@ http://usps.com-trackcfm.top/us/
 http://usps.com-trackckk.top/us/
 http://usps.com-trackcox.top/us/
 http://usps.com-trackcpv.top/us/
+http://usps.com-trackcqi.top/us/
 http://usps.com-trackcuf.top/us/
 http://usps.com-trackdac.top/us/
 http://usps.com-trackdax.top/us/
@@ -1439,6 +1441,7 @@ http://usps.com-tracknmp.top/us/
 http://usps.com-tracknnt.top/us/
 http://usps.com-tracknnu.top/us/
 http://usps.com-tracknom.top/us/
+http://usps.com-tracknpt.top/us/
 http://usps.com-tracknsn.top/us/
 http://usps.com-tracknul.top/us/
 http://usps.com-tracknuo.top/us/
@@ -1475,6 +1478,7 @@ http://usps.com-trackpdw.top/us/
 http://usps.com-trackpfg.top/us/
 http://usps.com-trackpgw.top/us/
 http://usps.com-trackphe.top/us/
+http://usps.com-trackphy.top/us/
 http://usps.com-trackpiw.top/us/
 http://usps.com-trackpjx.top/us/
 http://usps.com-trackpkp.top/us/
@@ -1490,6 +1494,7 @@ http://usps.com-trackppy.top/us/
 http://usps.com-trackpql.top/us/
 http://usps.com-trackpre.top/us/
 http://usps.com-trackpri.top/us/
+http://usps.com-trackpro.top/us/
 http://usps.com-trackpsj.top/us/
 http://usps.com-trackpts.top/us/
 http://usps.com-trackpwf.top/us/
@@ -1528,6 +1533,7 @@ http://usps.com-trackrex.top/us/
 http://usps.com-trackrfs.top/us/
 http://usps.com-trackrgy.top/us/
 http://usps.com-trackrhn.top/us/
+http://usps.com-trackrip.top/us/
 http://usps.com-trackriq.top/us/
 http://usps.com-trackriy.top/us/
 http://usps.com-trackrjr.top/us/
@@ -1561,6 +1567,7 @@ http://usps.com-tracksoc.top/us/
 http://usps.com-tracksok.top/us/
 http://usps.com-tracksom.top/us/
 http://usps.com-trackspu.top/us/
+http://usps.com-tracksqf.top/us/
 http://usps.com-tracksqh.top/us/
 http://usps.com-tracksql.top/us/
 http://usps.com-tracksqr.top/us/
@@ -1636,6 +1643,7 @@ http://usps.com-trackvry.top/us/
 http://usps.com-trackvsb.top/us/
 http://usps.com-trackvst.top/us/
 http://usps.com-trackvta.top/us/
+http://usps.com-trackvtk.top/us/
 http://usps.com-trackvui.top/us/
 http://usps.com-trackvuv.top/us/
 http://usps.com-trackvvk.top/us/
@@ -1720,7 +1728,9 @@ http://usps.com-trackyog.top/us/
 http://usps.com-trackyoy.top/us/
 http://usps.com-trackypa.top/us/
 http://usps.com-trackypd.top/us/
+http://usps.com-trackyqn.top/us/
 http://usps.com-trackyri.top/us/
+http://usps.com-trackysb.top/us/
 http://usps.com-trackyte.top/us/
 http://usps.com-trackyto.top/us/
 http://usps.com-trackyvc.top/us/


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```

```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```

```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
When reviewing #736 I noticed that I had mistakenly placed a batch of URIs in the domain list instead of the link list.  This fixes that error.

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
