### PR TITLE
Update remove  entire xeroshoes-canada.com

### DIFF
--- a/add-wildcard-domain
+++ b/add-wildcard-domain
@@ -2847,6 +2847,7 @@ workshopstyle.com
 workshopusers.com
 worldwidewebshield.info
 wszc7.asia
+xeroshoes-canada.com
 xn--ameli--niveau-sms-tob.com
 xn--espace-vitale--jours-sms-87b.com
 xn--espace-vitale--niveau-sms-zbc.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):

```
www.xeroshoes-canada.com
```


## Impersonated domain

```
xeroshoes.com
```

## Describe the issue

`www.xeroshoes-canada.com` is impersonating `xeroshoes.com` in great detail and extracts money from visiting victims. Presently registered with `Xin Net Technology Corporation` known for registering illicit domains. 

## Related external source


### Screenshot

<details><summary>Click to expand</summary>

![image](https://github.com/user-attachments/assets/363379ea-94ad-4b60-acff-888bb4ead0de)

![image](https://github.com/user-attachments/assets/986d243a-2ab6-4db7-985d-8a74486ebe90)

</details>
