### PR TITLE
Add doh-gov.com and doh-gov.ph

### DIFF
--- a/add-wildcard-domain
+++ b/add-wildcard-domain
@@ -2173,6 +2173,8 @@ diezestrellas.com
 dofus-events.com
 dofuspourlenoobs.com
 dofusprourlesnoobs.com
+doh-gov.com
+doh-gov.ph
 dolaxabof.xyz
 dorfuspourlesnoobs.com
 download-binance.online


### PR DESCRIPTION
Spoofing and masquerading a Philippine government website to sell a fake health product. Collects personally identifiable information such as names, email, contact numbers, and credit card numbers.

Examples of URLs from these domains are:

```
doh-gov.com
doh-gov.ph
http://www.doh-gov.com/cholextrol
http://www.doh-gov.ph/cholextrol
http://www.doh-gov.com/fda.thyroid
```

## Phishing Domain/URL/IP(s):

```
http://www.doh-gov.com/cholextrol
http://www.doh-gov.ph/cholextrol
http://www.doh-gov.com/fda.thyroid
```


## Impersonated domain

```
doh.gov.ph
```

## Describe the issue
Spoofing and masquerading a Philippine government website to sell a fake health product. Collects personally identifiable information such as names, email, contact numbers, and credit card numbers.


## Related external source


### Screenshot


<details><summary>Screenshot, click to unfold</summary>
<p>

![image](https://github.com/user-attachments/assets/055cfe10-00b8-46b3-9c0d-3eccde0de181)

![image](https://github.com/user-attachments/assets/05dd3679-0818-4d6c-92a6-95ac01514c3b)

</p>
</details> 