### PR TITLE
Add www.amazon.com to false positive list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -244,3 +244,4 @@ gmailonline.us
 microsoftsupport.us
 su.vc
 cargotrans.vn
+www.amazon.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
www.amazon.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
N/A
```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->

www.amazon.com is a legitimate and globally trusted domain owned by Amazon. It appears this domain may have been mistakenly flagged as phishing by automated detection systems or user reports. This pull request adds it to the falsepositive.list to prevent future false positives and improve the accuracy of this database. Currently, this domain is reported as phishing on Virustotal. See screenshot

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

https://www.virustotal.com/gui/domain/www.amazon.com?nocache=1

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

https://www.virustotal.com/gui/domain/www.amazon.com?nocache=1

<details><summary>Click to expand</summary>

 This pull request adds www.amazon.com added to the falsepositive.list. This is a legitimate domain that may have been incorrectly flagged by phishing detection systems. Adding it here helps reduce false positives in automated tools relying on this database.

</details>
