### PR TITLE
Block docssa.online and secured21.elektro-cigerli.com

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1,3 +1,5 @@
+docssa.online
+secured21.elektro-cigerli.com
 gosuslugi.agency
 bitcoin-core.app
 coronavirus.app


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
docssa.online
secured21.elektro-cigerli.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
www.ssa.gov
```

## Describe the issue
A spam is sent by using research.net online survey tool.

![Screenshot_20250615_083451](https://github.com/user-attachments/assets/213feafa-a5ea-45d0-ab02-7bb238e64993)

The button leads to this link:

```
https://www.research.net/tr/v1/te/YPLcUQNFl8Ix7Q3z86j8Omj9b1DL95FDgSM518PIEun0qg9E9miCNULIoxliQveWrb13u_2F0VN2S_2FlnrecHTl4EWiR4n5rFImTqOs0cJvuPwnymhCa6DEHN7AdMT94_2FU1M1f5tFeqemn_2FxyoDC24U3B56np1Tc0o036q1MpmH0Ew_3D
```

Which is redirected to:

```
http://secured21.elektro-cigerli.com
```

Note that only this subdomain seem to be compromised. The root domain is a legitimate functioning website from a private company. Also note that the compromised subdomain can only be accessed via http and NOT https.

This subdomain is then redirected to:

```
https://docssa.online
```

![image](https://github.com/user-attachments/assets/000b43f4-a5ab-4978-aa5f-e9fb0cfba0d1)


## Related external source
https://github.com/hagezi/dns-blocklists/issues/6483

