### PR TITLE
Block fish-lane.com

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1,3 +1,4 @@
+fish-lane.com
 gosuslugi.agency
 bitcoin-core.app
 coronavirus.app


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
fish-lane.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
dashlane.com
```

## Describe the issue
A spam mail with a link to fish-lane.com masquerades as a login screen from Dashlane, a popular password manager.

## Related external source
https://github.com/hagezi/dns-blocklists/issues/6629

### Screenshot
![image](https://github.com/user-attachments/assets/1ae08e0d-8774-4b72-b8ce-7007b5e5d245)

![image](https://github.com/user-attachments/assets/bde2b3ca-685d-4fab-82d4-908e21d38d53)
