### PR TITLE
Add ppy.wom.mybluehost.me and redirects

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1101,3 +1101,5 @@ zh-trust.com
 zk-manta-airdrop.pages.dev
 zt-za.fr
 zttmct-tlemp.web.app
+d3eaaylp894lcg.cloudfront.net
+ppy.wom.mybluehost.me

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -4120,3 +4120,4 @@ https://zmedtipp.live/mnvzx
 https://ppy.wom.mybluehost.me/;)rai/
 https://ppy.wom.mybluehost.me/;)rai/zpy.php
 https://d3eaaylp894lcg.cloudfront.net/d3b2ba10-b.html
+http://1970sblackandwhite.com/images/index.php

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -4117,3 +4117,6 @@ https://yeicotjj.github.io/auditoria/continue.html
 https://yonehunqpom.life/zpxd
 https://yuppiiechef.com/account/ű
 https://zmedtipp.live/mnvzx
+https://ppy.wom.mybluehost.me/;)rai/
+https://ppy.wom.mybluehost.me/;)rai/zpy.php
+https://d3eaaylp894lcg.cloudfront.net/d3b2ba10-b.html


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
https://d3eaaylp894lcg.cloudfront.net/d3b2ba10-b.html
https://ppy.wom.mybluehost.me/;)rai/zpy.php
https://ppy.wom.mybluehost.me/;)rai/
http://1970sblackandwhite.com/images/index.php
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
https://gestiondecuenta.eu/index.php?rp=/login
```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
These domains has been spoofing both the customer area and the login on the Raiola Networks website



## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
