### PR TITLE
Remove biaxol.eu

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -90,7 +90,6 @@ bcryp.net
 begincellcdn.pages.dev
 beritapb.com
 biaxol-supplements.com
-biaxol.eu
 bigbeans.solutions
 bilflyer.web.app
 bill-overdue.net

--- a/falsepositives/temporary/domains.list
+++ b/falsepositives/temporary/domains.list
@@ -1,4 +1,4 @@
-
+biaxol.eu
 dhlstafetten.dk
 hotm.art
 hsbcorsoemployer.wrkr.hk


### PR DESCRIPTION
Admin of this github project, funilrys, suggested to create PR to remove domain biaxol.eu from phishing list as it is no more malicious 
