### PR TITLE
Block security-firmware-update.sbs

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -1,3 +1,4 @@
+security-firmware-update.sbs
 123pan.cn
 2bit.ch
 2cvmedias.fr


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
safepal.security-firmware-update.sbs
security-firmware-update.sbs
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
safepal.com
```

## Describe the issue
A spam mail with a link to a compromised website redirects to the phishing domain.

<img width="1189" height="966" alt="Image" src="https://github.com/user-attachments/assets/379f627f-9305-429c-aff9-85d49a58df52" />


The phishing domain spoofs SafePal, a popular crypto wallet.

<img width="1558" height="886" alt="Image" src="https://github.com/user-attachments/assets/ff473b76-7688-45bd-a049-198e2b60e52c" />


Google Safe Browsing already blocks the page.

<img width="1667" height="1027" alt="Image" src="https://github.com/user-attachments/assets/c03e6fe4-e8be-4652-bd08-dadb84fe4d80" />


However to date, CloudFlare and NextDNS still does not block the domain

<img width="652" height="289" alt="Image" src="https://github.com/user-attachments/assets/9a2eb38b-d509-4e92-9064-ccc5d293a60e" />

## Related external source
https://phishtank.org/phish_detail.php?phish_id=9170877
https://github.com/hagezi/dns-blocklists/issues/6880