### PR TITLE
[False Negative]: add 2 phishing domains (sun-sun[.]org, app[.]sunwsap[.]net)

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1142,3 +1142,5 @@ zh-trust.com
 zk-manta-airdrop.pages.dev
 zt-za.fr
 zttmct-tlemp.web.app
+sun-sun.org
+app.sunwsap.net


### PR DESCRIPTION
## Executive Summary

This report documents 2 domain(s) that have been identified as part of active phishing operations. These domains exhibit characteristics consistent with malicious infrastructure and pose an immediate security risk to internet users.

The following 2 domain(s) have been analyzed and confirmed as participating in phishing campaign(s):

```
sun-sun.org
app.sunwsap.net
```

## Threat Analysis

### Phishing Attack Details
  
  These domains are part of a phishing campaign targeting сompanies and cryptocurrency holders/investors.
  The attackers use fake login pages and tampered software to steal seeds/keys.
  
  ### Technical Details
  
  - Use Cloudflare (maybe Pro or Business) accounts.
  - Cloaked, if the request does not comply with the rules, redirect to a non-existent subdomain "www.www." (in most cases)
  
  ### Detections
  - `sun-sun.org` - **0 detections** - https://www.virustotal.com/gui/domain/sun-sun.org/detection
- `app.sunwsap.net` - **0 detections** - https://www.virustotal.com/gui/domain/app.sunwsap.net/detection

  
### Targeted Brands

- sun-sun.org - SunSwap (sun.io)
- app.sunwsap.net - SunSwap (sun.io)

## Temporal Information

- **Date of Identification and Submission**: 2025-08-01 23:39 UTC
- **Estimated Campaign Activity Start**: Approximately 7-14 days prior to detection

## Screenshots

(If screenshots are not displayed, see the scans pages)

<details>
<summary>Screenshots</summary>

![Screenshot](https://urlscan.io/screenshots/019867fd-cf2c-7598-8564-e6187e81579a.png)

</details>



## Scans

- `sun-sun.org` - https://urlscan.io/result/019867fd-cf2c-7598-8564-e6187e81579a/
- `app.sunwsap.net` - https://urlscan.io/result/019867fd-cf2c-7598-8564-e6187e81579a/
