### PR TITLE
Block marketbid-os2.com and kams-alchouagi.com

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -1,3 +1,5 @@
+marketbid-os2.com
+kams-alchouagi.com
 123pan.cn
 2bit.ch
 2cvmedias.fr


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
marketbid-os2.com
kams-alchouagi.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
opensea.io
```

## Describe the issue

A phishing email with a call-to-action button link to `https://kams-alchouagi.com/opensea` will redirect you to `https://marketbid-os2.com/desktop.php`

<img width="1407" height="812" alt="Image" src="https://github.com/user-attachments/assets/f4e29515-2b54-49d8-b6de-c8b2b4227a65" />

<img width="1655" height="1033" alt="Image" src="https://github.com/user-attachments/assets/97c14939-85b2-4355-8223-72c727960f4b" />

The domain `kams-alchouagi.com` seems to be from a self professed scammer:

<img width="1420" height="1024" alt="Image" src="https://github.com/user-attachments/assets/cf8adf59-8033-40f3-956e-c2339106fc63" />

While the domain `marketbid-os2.com` leads to `opensea.io`.

There is strong reason to believe that these domains will be used to create other malicious subdomains and paths in the future.

## Related external source
https://github.com/hagezi/dns-blocklists/issues/6976
https://phishtank.org/phish_detail.php?phish_id=9181546
https://phishtank.org/phish_detail.php?phish_id=9181547