### PR TITLE
Add Steam phishing pages

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1666,3 +1666,6 @@ zh-trust.com
 zk-manta-airdrop.pages.dev
 zt-za.fr
 zttmct-tlemp.web.app
+gameschallenger.com
+gamermode.world
+gamechallange.com

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -4905,3 +4905,6 @@ https://yeicotjj.github.io/auditoria/continue.html
 https://yonehunqpom.life/zpxd
 https://yuppiiechef.com/account/ű
 https://zmedtipp.live/mnvzx
+https://gameschallenger.com/
+https://gamermode.world/
+https://gamechallange.com/


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):

```
gameschallenger.com
gamermode.world
gamechallange.com
https://gameschallenger.com/
https://gamermode.world/
https://gamechallange.com/
```


## Impersonated domain

```
faceit.com
```

## Describe the issue
They are Steam Phishing Pages. If you press "Play Now" and then "Login", a fake Steam window will open.


## Related external source

https://www.virustotal.com/gui/url/4c7d771abff9e90bb3d0d6592d85b971594045af6b2c6351845e217a1348aea7
https://www.virustotal.com/gui/url/ad325ff1018c16c09e6069bceecf11c95e8d6c0e4c77f151efeb08c43d62a67f
https://www.virustotal.com/gui/url/a7d1e02533dc96b54d1cdc63803bfeb13b5cf8e1ae4b810e14908c3039578fba


### Screenshot

<details><summary>Click to expand</summary>

<img width="2561" height="1352" alt="gamechallange" src="https://github.com/user-attachments/assets/e285e523-64a7-4f44-b860-0562c336759b" />

</details>
