### PR TITLE
Add Steam Phishing Pages

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -3053,3 +3053,6 @@ yousweeps.com
 zinhice.shop
 zmedtipp.live
 zxvbcrt.ug
+lobbyjoin.pro
+2v2lobby.pro
+lobby-51804.pro

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -4909,3 +4909,7 @@ https://yeicotjj.github.io/auditoria/continue.html
 https://yonehunqpom.life/zpxd
 https://yuppiiechef.com/account/ű
 https://zmedtipp.live/mnvzx
+https://faceit.lobbyjoin.pro/lobby
+https://faceit.2v2lobby.pro/inv
+https://faceit.lobby-51804.pro/
+https://faceit.lobby-51804.pro/invite


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
lobbyjoin.pro
2v2lobby.pro
lobby-51804.pro
https://faceit.lobbyjoin.pro/lobby
https://faceit.2v2lobby.pro/inv
https://faceit.lobby-51804.pro/
https://faceit.lobby-51804.pro/invite
```


## Impersonated domain
```
faceit.com
```

## Describe the issue
Steam Phishing Sites. You have to press “Accept Invite” and then “Check-In”. After that, a fake Steam login window is opened.


## Related external source
https://www.virustotal.com/gui/url/5a423478194556bcba44111807e1f108cc65b4a553ca13ce1ba12580e833cfd5
https://www.virustotal.com/gui/url/e8039b7b9a93608e13019695eb9ece040989873e24740faaf76a43096d805db7
https://www.virustotal.com/gui/url/23301569445317e612707024da978343eac47bcd6015a2ca2556f49eacfefd4f?nocache=1

### Screenshot

<details><summary>Click to expand</summary>

<img width="2559" height="1274" alt="lobbyid" src="https://github.com/user-attachments/assets/0f3cb51c-406a-4be0-aed7-7c1252491d09" />

</details>
