### PR TITLE
Block support-ledger-recover.com

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,5 @@
+support-ledger-recover.com
+safe-recover.s3.us-east-1.amazonaws.com
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
support-ledger-recover.com
safe-recover.s3.us-east-1.amazonaws.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
ledger.com
```

## Describe the issue
A phishing email with a call to action button linked to `https://safe-recover.s3.us-east-1.amazonaws.com/recover.html` redirects to `https://support-ledger-recover.com/`

<img width="1390" height="872" alt="Image" src="https://github.com/user-attachments/assets/5294d00c-8657-4cdf-9264-7f18c5612889" />

<img width="1547" height="1028" alt="Image" src="https://github.com/user-attachments/assets/0dad1c5c-1799-4e00-8063-e8e96f35e7c2" />

## Related external source
https://github.com/hagezi/dns-blocklists/issues/7230
https://phishtank.org/phish_detail.php?phish_id=9203249
https://phishtank.org/phish_detail.php?phish_id=9203250
https://phishtank.org/phish_detail.php?phish_id=9203257
