### PR TITLE
Add Steam Phishing Page and update eplseason.com

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -3879,3 +3879,6 @@ yousweeps.com
 zinhice.shop
 zmedtipp.live
 zxvbcrt.ug
+workshop-arts.pro
+lanberfom.pro
+dogesvsrelax.icu

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -6340,3 +6340,5 @@ https://yeicotjj.github.io/auditoria/continue.html
 https://yonehunqpom.life/zpxd
 https://yuppiiechef.com/account/ű
 https://zmedtipp.live/mnvzx
+https://workshop-arts.pro/artwork
+https://dogesvsrelax.icu/71613


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
```
workshop-arts.pro
lanberfom.pro
dogesvsrelax.icu
https://workshop-arts.pro/artwork
https://dogesvsrelax.icu/71613
```


## Impersonated domain
```
steamcommunity.com
```

## Describe the issue
This will add dogesvsrelax.icu, which is related to [#973 ]. Thanks to @ninjacatcher. Also, it will add another Steam phishing page and its command-and-control server (lanberfom.pro). This site pretends to be a Rust skin voting page.


## Related external source
https://urlscan.io/result/019972f7-2fb8-70cb-a845-af8aa45606ac/
https://urlscan.io/result/019972e2-ce4c-759b-be07-acccf0f5cecf/

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>
<img width="1600" height="1200" alt="019972f7-2fb8-70cb-a845-af8aa45606ac" src="https://github.com/user-attachments/assets/5e87ef54-b076-4d5d-87f6-200e3bfaa4e4" />
<img width="1600" height="1200" alt="019972e2-ce4c-759b-be07-acccf0f5cecf" src="https://github.com/user-attachments/assets/6ef324b3-f4a6-418d-86f8-0b02cf23eec5" />

</details>
