### PR TITLE
Update 94.74.164.47 - Steam Phishing

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -3894,3 +3894,4 @@ zavod228.icu
 zinhice.shop
 zmedtipp.live
 zxvbcrt.ug
+workshopsharedmods.com

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -6381,3 +6381,9 @@ https://yeicotjj.github.io/auditoria/continue.html
 https://yonehunqpom.life/zpxd
 https://yuppiiechef.com/account/ű
 https://zmedtipp.live/mnvzx
+https://store.workshopsharedmods.com/sharedfiles/filesdetails/aug_poseidon/
+https://login.workshopsharedmods.com/sharedfiles/filesdetails/aug_poseidon/
+https://store.workshopsharedmods.com/sharedfiles/filesdetails/mac-10_poison_revenge/
+https://login.workshopsharedmods.com/sharedfiles/filesdetails/mac-10_poison_revenge/
+https://store.workshopsharedmods.com/openid/login/openidmodecheckid_setup_http3A2Fspecsopenid2Fauth2F20openid/nssreg=http3A2Fopenidnet3Fextensions1openi=optional/
+https://login.workshopsharedmods.com/openid/login/openidmodecheckid_setup_http3A2Fspecsopenid2Fauth2F20openid/nssreg=http3A2Fopenidnet3Fextensions1openi=optional/


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
```
workshopsharedmods.com
https://store.workshopsharedmods.com/sharedfiles/filesdetails/aug_poseidon/
https://login.workshopsharedmods.com/sharedfiles/filesdetails/aug_poseidon/
https://store.workshopsharedmods.com/sharedfiles/filesdetails/mac-10_poison_revenge/
https://login.workshopsharedmods.com/sharedfiles/filesdetails/mac-10_poison_revenge/
https://store.workshopsharedmods.com/openid/login/openidmodecheckid_setup_http3A2Fspecsopenid2Fauth2F20openid/nssreg=http3A2Fopenidnet3Fextensions1openi=optional/
https://login.workshopsharedmods.com/openid/login/openidmodecheckid_setup_http3A2Fspecsopenid2Fauth2F20openid/nssreg=http3A2Fopenidnet3Fextensions1openi=optional/
```


## Impersonated domain
```
steamcommunity.com
```

## Describe the issue
Steam Phishing. Fake Steam workshop item voting page.

## Related external source

https://urlscan.io/result/01997c79-a966-718b-8747-896a6388147f/
https://urlscan.io/result/01997c7a-352f-76d9-8bb8-c83509d9bffa/
https://urlscan.io/result/01997c7a-bd1a-75cf-b4be-083b829af24e/
https://urlscan.io/result/01997c7b-459e-75fe-b2bc-42ebf75122ef/
https://urlscan.io/result/01997c7b-d027-7224-8237-0d3dcaa516df/
https://urlscan.io/result/01997c7c-3537-70be-86c7-9791b12fa797/

### Screenshot

<details><summary>Click to expand</summary>
<img width="2557" height="1266" alt="7" src="https://github.com/user-attachments/assets/8c134a4c-a699-47b5-b0e9-c720e384111a" />
<img width="2555" height="1271" alt="2" src="https://github.com/user-attachments/assets/59c9514b-bfec-4d26-95da-6c2183ad834b" />
<img width="2556" height="1272" alt="1" src="https://github.com/user-attachments/assets/e046111e-eb51-4446-a572-0b8ef31067f6" />


</details>
