### PR TITLE
Add a Steam Phishing Site - teams-legendscup.com

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -3917,3 +3917,4 @@ zavodik11.help
 zinhice.shop
 zmedtipp.live
 zxvbcrt.ug
+teams-legendscup.com

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -6421,3 +6421,7 @@ https://yonehunqpom.life/zpxd
 https://yuppiiechef.com/account/ű
 https://zavodik11.help/7acab
 https://zmedtipp.live/mnvzx
+https://teams-legendscup.com/
+https://www.teams-legendscup.com/
+https://faceit.teams-legendscup.com/
+https://www.faceit.teams-legendscup.com/


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
```
teams-legendscup.com
https://teams-legendscup.com/
https://www.teams-legendscup.com/
https://faceit.teams-legendscup.com/
https://www.faceit.teams-legendscup.com/
```


## Impersonated domain
```
steamcommunity.com
```

## Describe the issue
Steam Phishing. If you select a Team und then press “Get Invite/Vote”, then “Check-In”, a fake Steam login window will be opened.

## Related external source
https://urlscan.io/result/01998777-7ba7-75e9-a413-2d40d1d28347/
https://urlscan.io/result/01998777-8a5e-71d4-ba37-b1fce48c6215/
https://urlscan.io/result/01998777-9c8b-71bd-abfd-47051e890f34/
https://urlscan.io/result/01998777-acca-75ab-964d-4707ec1d60a9/

### Screenshot
<details><summary>Click to expand</summary>
<img width="2557" height="1273" alt="Screenshot 2025-09-26 192532" src="https://github.com/user-attachments/assets/42f7a08b-c2fa-4994-8cbf-4c543b64de0b" />


</details>
