### PR TITLE
Add a bank phishing site

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -3932,3 +3932,4 @@ zavodik11.help
 zinhice.shop
 zmedtipp.live
 zxvbcrt.ug
+myonline-account.xyz

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -6482,3 +6482,5 @@ https://yuppiiechef.com/account/ű
 https://zavodik11.help/7acab
 https://zmedtipp.live/mnvzx
 jinghua-cs2.com
+https://urly.it/31cb7j
+https://barclays.myonline-account.xyz/index.html


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
```
myonline-account.xyz
https://urly.it/31cb7j
https://barclays.myonline-account.xyz/index.html
```


## Impersonated domain
```
https://www.barclays.de/
```

## Describe the issue
Phishing of the Barclays bank.


## Related external source
https://urlscan.io/result/0199999b-25f8-735c-a941-29a8cde8ef72/


### Screenshot
<details><summary>Click to expand</summary>
<img width="2556" height="1275" alt="Screenshot 2025-09-30 094746" src="https://github.com/user-attachments/assets/0e7b187a-6d2c-4152-bc26-ff72294c9d99" />

</details>
