### PR TITLE
Add a Steam Phishing site - rustpale.com

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -3935,3 +3935,5 @@ zavodik11.help
 zinhice.shop
 zmedtipp.live
 zxvbcrt.ug
+rustpale.com
+givemewin.ru

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -6484,5 +6484,4 @@ https://yonehunqpom.life/zpxd
 https://yuppiiechef.com/account/ű
 https://zavodik11.help/7acab
 https://zmedtipp.live/mnvzx
-jinghua-cs2.com
-http://rustpale.com/
+https://rustpale.com/

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -6485,3 +6485,4 @@ https://yuppiiechef.com/account/ű
 https://zavodik11.help/7acab
 https://zmedtipp.live/mnvzx
 jinghua-cs2.com
+http://rustpale.com/


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
```
rustpale.com
givemewin.ru
https://rustpale.com/
```


## Impersonated domain
```
steamcommunity.com
```

## Describe the issue
Steam Phishing. Fake Rust skin voting site. givemewin.ru is the command-and-control server.

This PR will also remove a domain from the link list, which I accidently added in [#990].

## Related external source
https://urlscan.io/result/01999c96-2f0a-7468-b09e-8ae76a6e19ab/


### Screenshot
<details><summary>Click to expand</summary>
<img width="1600" height="1200" alt="01999c96-2f0a-7468-b09e-8ae76a6e19ab" src="https://github.com/user-attachments/assets/220cd96b-052b-462c-9a17-de34da073495" />

</details>
