### PR TITLE
Update 94.74.164.255 - Steam Phishing

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -3945,3 +3945,5 @@ zavodik11.help
 zinhice.shop
 zmedtipp.live
 zxvbcrt.ug
+communitygamebuild.com
+poweredartstyle.shop

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -6503,3 +6503,7 @@ https://yuppiiechef.com/account/ű
 https://zavodik11.help/7acab
 https://zmedtipp.live/mnvzx
 https:/eschallenger.world/
+https://store.communitygamebuild.com/sharedfiles/filedetails/id=22958664/
+https://www.store.communitygamebuild.com/sharedfiles/filedetails/id=22958664/
+https://store.poweredartstyle.shop/sharedfiles/filedetails/id=37895845/
+https://www.store.poweredartstyle.shop/sharedfiles/filedetails/id=37895845/


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
```
communitygamebuild.com
poweredartstyle.shop
https://store.communitygamebuild.com/sharedfiles/filedetails/id=22958664/
https://www.store.communitygamebuild.com/sharedfiles/filedetails/id=22958664/
https://store.poweredartstyle.shop/sharedfiles/filedetails/id=37895845/
https://www.store.poweredartstyle.shop/sharedfiles/filedetails/id=37895845/
```


## Impersonated domain
```
steamcommunity.com
```

## Describe the issue
Steam Phishing. Fake Steam Workshop voting sites.

## Related external source
https://urlscan.io/result/0199a627-fc16-743e-a080-6cf94dac9b66/
https://urlscan.io/result/0199a627-fe48-717d-9fe2-ab224d0718e9/
https://urlscan.io/result/0199a627-f78b-755b-864c-4641021ea479/
https://urlscan.io/result/0199a627-fbc7-708d-8e24-327956fd5318/

### Screenshot
<details>
<img width="1600" height="1200" alt="0199a627-f78b-755b-864c-4641021ea479 (1)" src="https://github.com/user-attachments/assets/96af3535-768d-4283-922f-bc1c848621a7" />
<img width="1600" height="1200" alt="0199a627-fc16-743e-a080-6cf94dac9b66 (1)" src="https://github.com/user-attachments/assets/82eb6a00-8926-4283-a578-e50a9be73d41" />




</details>
