### PR TITLE
Add two Steam Phishing sites

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -3955,3 +3955,6 @@ zavodik11.help
 zinhice.shop
 zmedtipp.live
 zxvbcrt.ug
+faceit-authclub.com
+zavodka842.help
+rustbrute.com

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -6520,3 +6520,7 @@ https://yuppiiechef.com/account/ű
 https://zavodik11.help/7acab
 https://zmedtipp.live/mnvzx
 https:/eschallenger.world/
+https://faceit-authclub.com/
+https://faceit-authclub.com/game/?game=leagues5v5&skill_level=all&game_type_2=5vs5&source=faceit
+https://zavodka842.help/0bdbf
+https://rustbrute.com/


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
```
faceit-authclub.com
zavodka842.help
rustbrute.com
https://faceit-authclub.com/
https://faceit-authclub.com/game/?game=leagues5v5&skill_level=all&game_type_2=5vs5&source=faceit
https://zavodka842.help/0bdbf
https://rustbrute.com/
```


## Impersonated domain
```
steamcommunity.com
```

## Describe the issue
Steam Phishing. One is a fake FaceIt verifying site, the other is a fake Rust Skin Voting site.  zavodka842.help is the command-and-control server of faceit-authclub.com.

## Related external source
https://urlscan.io/result/0199aba3-c109-747d-bb91-290569b4cf0c/


### Screenshot

<details><summary>Click to expand</summary>
<img width="1600" height="1200" alt="0199abec-232b-73b9-a852-fdb62e36b42c" src="https://github.com/user-attachments/assets/01241c6d-0b47-4c38-a89d-f2bd482717d0" />
<img width="1600" height="1200" alt="0199aba3-c109-747d-bb91-290569b4cf0c" src="https://github.com/user-attachments/assets/eb84c534-08c1-463c-b2a0-dffa7bdfa986" />


</details>
