### PR TITLE
Add a Phishing site of the German Telekom

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -3958,3 +3958,5 @@ zavodka842.help
 zinhice.shop
 zmedtipp.live
 zxvbcrt.ug
+fc8881.cc
+aktivitatsverlauf-uberprufung.de

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -6524,3 +6524,4 @@ https://zavodik11.help/7acab
 https://zavodka842.help/0bdbf
 https://zmedtipp.live/mnvzx
 https:/eschallenger.world/
+https://aktivitatsverlauf-uberprufung.de/start/


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
```
fc8881.cc
aktivitatsverlauf-uberprufung.de
https://aktivitatsverlauf-uberprufung.de/start/
```


## Impersonated domain
```
www.telekom.de
```

## Describe the issue
It's a Phishing site of the German Telekom. fc8881.cc will redirect to the phishing site. I won't share the link of fc8881.cc, because it contains tracking codes.


## Related external source
https://urlscan.io/result/0199aea8-6407-77de-a623-97ecd3184568/


### Screenshot
<details><summary>Click to expand</summary>
<img width="2555" height="1273" alt="Screenshot 2025-10-04 115904" src="https://github.com/user-attachments/assets/cb556a9c-4009-4fe2-9f72-f73d7389ba6e" />


</details>
