### PR TITLE
Update 91.200.14.203 - Steam Phishing

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -3958,3 +3958,5 @@ zavodka842.help
 zinhice.shop
 zmedtipp.live
 zxvbcrt.ug
+masterscs2series.com
+ssssss6ssssss.top

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -6524,3 +6524,6 @@ https://zavodik11.help/7acab
 https://zavodka842.help/0bdbf
 https://zmedtipp.live/mnvzx
 https:/eschallenger.world/
+https://masterscs2series.com/
+https://www.masterscs2series.com/
+https://ssssss6ssssss.top/0eb37


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
```
masterscs2series.com
ssssss6ssssss.top
https://masterscs2series.com/
https://www.masterscs2series.com/
https://ssssss6ssssss.top/0eb37
```


## Impersonated domain
```
steamcommunity,com
```

## Describe the issue
Steam Phishing. Fake esport Team voting site. ssssss6ssssss.top is the c2 of masterscs2series.com


## Related external source
https://urlscan.io/result/0199b07d-3fba-726c-8df4-af968d1fb6ec/
https://urlscan.io/result/0199b07d-53b2-732a-b62b-7f2ce5dd129e/

### Screenshot
<details><summary>Click to expand</summary>
<img width="1600" height="1200" alt="0199b07d-3fba-726c-8df4-af968d1fb6ec" src="https://github.com/user-attachments/assets/6ed92c35-48aa-4ec1-870f-94d4bbf1cca4" />

</details>
