### PR TITLE
Block Trezor Entropy Phishing Campaign

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,13 @@
+camelpetroleum.com
+cargospheremarket.com
+entropy-check-portal.com
+grupollado.com
+syncledgerwallet.live
+trezor.check-entropy-dashboard.com
+trezor.check-entropy-verification.com
+trezor.entropy-update-dashboard.com
+trezor.protocol-entropy-check.com
+trezor.protocol-entropy-dashboard.com
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com

--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -1,3 +1,8 @@
+check-entropy-dashboard.com
+check-entropy-verification.com
+entropy-update-dashboard.com
+protocol-entropy-check.com
+protocol-entropy-dashboard.com
 123pan.cn
 13afx.top
 17fdg.xyz


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
camelpetroleum.com
cargospheremarket.com
entropy-check-portal.com
grupollado.com
syncledgerwallet.live
trezor.check-entropy-dashboard.com
trezor.check-entropy-verification.com
trezor.entropy-update-dashboard.com
trezor.protocol-entropy-check.com
trezor.protocol-entropy-dashboard.com
*.check-entropy-dashboard.com
*.check-entropy-verification.com
*.entropy-update-dashboard.com
*.protocol-entropy-check.com
*.protocol-entropy-dashboard.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
trezor.io
```

## Describe the issue
Three similar phishing email was received with a link to `https://camelpetroleum.com/ehy/?id=3DY2FtZWxwZXRyb2xldW0uY29t`, `https://grupollado.com/ehy/?id=3DZ3J1cG9sbGFkby5jb20`, and `https://syncledgerwallet.live` respectively.

The first two links redirected to `https://cargospheremarket.com/?id=*` and further redirected to `https://trezor.check-entropy-dashboard.com/entropy-dashboard/?id=`, a spoofed page of Trezor which is a well known hardware crypto wallet.



A simple query to urlscan.io shows other similar domains related to this campaign.

```
page.url:"entropy-dashboard" OR page.url:"entropy-check" OR page.url:"entropy-verif"
```

- entropy-check-portal.com
- trezor.check-entropy-verification.com
- trezor.entropy-update-dashboard.com
- trezor.protocol-entropy-check.com
- trezor.protocol-entropy-dashboard.com

## Related external source
