### PR TITLE
Block v1x.362.mytemp.website

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,4 @@
+v1x.362.mytemp.website
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -1,3 +1,4 @@
+https://v1x.362.mytemp.website/BE/
 http://147.45.44.131/infopage/resafh7.exe
 http://147.45.44.131/infopage/vgqvs.bat
 http://147.45.44.131/infopage/vtqrai.exe


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
https://v1x.362.mytemp.website/BE/
mytemp.website
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
https://homebank.argenta.be/webapp/nl/aanmelden
```

## Describe the issue
In response to https://github.com/Phishing-Database/Phishing.Database/issues/1863

The website is benign for now but is still alive and resolves to an IP address. It may be a sleeper domain that can be reactivated for another campaign.

<img width="640" height="552" alt="image" src="https://github.com/user-attachments/assets/538f868d-1438-44a7-9cd2-37a7f7fd0b9a" />

It is best to keep this in the Phishing Database for now.