### PR TITLE
Block indibigining.com

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,5 @@
+indibigining.com
+09235authinformations.indibigining.com
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com

--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -1,3 +1,4 @@
+indibigining.com
 123pan.cn
 13afx.top
 17fdg.xyz


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
https://09235authinformations.indibigining.com/b90c3596-0471-9338-ec65-b95e55c1150c/login
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
netflix.com
```

## Describe the issue
As reported here: https://github.com/Phishing-Database/Phishing.Database/issues/1910

The website is benign for now but is still alive and resolves to an IP address. It may be a sleeper domain that can be reactivated for another campaign.

<img width="640" height="924" alt="image" src="https://github.com/user-attachments/assets/ee3c5408-588b-457f-b71b-892341155ce6" />

It is best to keep this in the Phishing Database for now.