### PR TITLE
Block Compromised fixamo.app domain

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,5 @@
+supercond.agenciatecnet.com.br
+fixamo.app
 09235authinformations.indibigining.com
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
supercond.agenciatecnet.com.br
fixamo.app
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
robinhood.com
NASA
FBI
```

## Describe the issue
A phishing email spoofing a notification from Robinhood Crypto was received with a link to `https://supercond.agenciatecnet.com.br`.

<img width="515" height="506" alt="Screenshot_20260901_142332" src="https://github.com/user-attachments/assets/59a9925a-1e31-46c8-9509-0c6bc3cd763b" />

The link redirects to `https://fixamo.app`

<img width="582" height="100" alt="Screenshot_20260901_074028" src="https://github.com/user-attachments/assets/5db85e4f-ee8d-4a87-8761-86415fbfe40a" />

Interestingly, `https://fixamo.app` redirects to either NASA's website (usually on the very first try) or the FBI (on succeeding tries).

<img width="521" height="143" alt="Screenshot_20260901_074145" src="https://github.com/user-attachments/assets/3fb5cc67-a5a9-4c2b-84b0-805cc9b053ea" />


## Related external source
