### PR TITLE
Block bpi-davao.com

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,4 @@
+bpi-davao.com
 09235authinformations.indibigining.com
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev

--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -1,3 +1,4 @@
+bpi-davao.com
 123pan.cn
 13afx.top
 17fdg.xyz

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -1,3 +1,4 @@
+https://bpi-davao.com/ph
 http://147.45.44.131/infopage/resafh7.exe
 http://147.45.44.131/infopage/vgqvs.bat
 http://147.45.44.131/infopage/vtqrai.exe


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
bpi-davao.com
*.bpi-davao.com
https://bpi-davao.com/ph
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
bpi.com.ph
```

## Describe the issue
An sms phishing was received with a link to `https://bpi-davao.com/ph`.

<img width="720" height="1600" alt="image" src="https://github.com/user-attachments/assets/135fcfdd-9f2c-4021-a4e9-e6f11bef0f0f" />

As of this time of reporting the website does not return content but is still resolving to an IP address.

<img width="793" height="376" alt="image" src="https://github.com/user-attachments/assets/8a9815d7-4fe2-4031-93c6-07f18ce76ce6" />

<img width="455" height="454" alt="image" src="https://github.com/user-attachments/assets/0a532b39-00f8-49cd-93db-1d93a13a8bdd" />

This is probably a sleeper domain and can be activated again in future phishing campaigns.

Also, I speculate that the campaign is similar to https://github.com/Phishing-Database/phishing/pull/1211 and https://github.com/Phishing-Database/phishing/pull/1217. Interestingly, the IP address is also under Alibaba just like with https://github.com/Phishing-Database/phishing/pull/1211

<img width="670" height="283" alt="image" src="https://github.com/user-attachments/assets/106bb475-8cd8-4ada-a54c-daac4dc7f364" />